### PR TITLE
handle 404 error from GCS the same as blob == null

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -37,7 +37,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'net.idlestate:gradle-gcs-build-cache:1.0.0'
+        classpath 'net.idlestate:gradle-gcs-build-cache:1.0.1'
     }
 }
 
@@ -71,7 +71,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'net.idlestate:gradle-gcs-build-cache:1.0.0'
+        classpath 'net.idlestate:gradle-gcs-build-cache:1.0.1'
     }
 }
 
@@ -108,7 +108,7 @@ initscript {
     }
 
     dependencies {
-        classpath 'net.idlestate:gradle-gcs-build-cache:1.0.0'
+        classpath 'net.idlestate:gradle-gcs-build-cache:1.0.1'
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,23 +3,23 @@ import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 
 plugins {
     `java-gradle-plugin`
-    kotlin("jvm") version "1.3.20"
-    id("com.github.hierynomus.license") version "0.14.0"
+    kotlin("jvm") version "1.3.31"
+    id("com.github.hierynomus.license") version "0.15.0"
     id("com.gradle.plugin-publish") version "0.10.1"
+    `kotlin-dsl`
     `maven-publish`
-    id("org.jlleitschuh.gradle.ktlint") version "7.0.0"
+    id("org.jlleitschuh.gradle.ktlint") version "8.2.0"
 }
 
 group = "net.idlestate"
-version = "1.0.0"
+version = "1.0.1"
 
 repositories {
-    mavenCentral()
     jcenter()
 }
 
 dependencies {
-    implementation("com.google.cloud:google-cloud-storage:1.61.0")
+    implementation("com.google.cloud:google-cloud-storage:1.86.0")
     implementation(kotlin("stdlib-jdk8"))
 }
 
@@ -44,12 +44,8 @@ pluginBundle {
     tags = listOf("build-cache", "gcs", "Google Cloud Storage", "cache")
 }
 
-val compileKotlin: KotlinCompile by tasks
-compileKotlin.kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_1_8.toString()
-}
-
-val compileTestKotlin: KotlinCompile by tasks
-compileTestKotlin.kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_1_8.toString()
+tasks.withType<KotlinCompile>().all {
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
+    }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/net/idlestate/gradle/caching/GCSBuildCache.kt
+++ b/src/main/kotlin/net/idlestate/gradle/caching/GCSBuildCache.kt
@@ -22,5 +22,8 @@ import org.gradle.caching.configuration.AbstractBuildCache
  *
  * @author Thorsten Ehlers (thorsten.ehlers@googlemail.com) (initial creation)
  */
-open class GCSBuildCache(var credentials: String? = "", var bucket: String? = "", var refreshAfterSeconds: Int? = 0)
-    : AbstractBuildCache()
+abstract class GCSBuildCache(
+    var credentials: String? = "",
+    var bucket: String? = "",
+    var refreshAfterSeconds: Int? = 0
+) : AbstractBuildCache()

--- a/src/main/kotlin/net/idlestate/gradle/caching/GCSBuildCachePlugin.kt
+++ b/src/main/kotlin/net/idlestate/gradle/caching/GCSBuildCachePlugin.kt
@@ -25,10 +25,11 @@ import org.gradle.api.initialization.Settings
  */
 class GCSBuildCachePlugin : Plugin<Settings> {
     override fun apply(settings: Settings) {
-        val buildCacheConfiguration = settings.buildCache
-        buildCacheConfiguration.registerBuildCacheService(GCSBuildCache::class.java, GCSBuildCacheServiceFactory::class.java)
-
-        val cache = buildCacheConfiguration.remote(GCSBuildCache::class.java)
-        cache.isPush = true
+        settings.buildCache {
+            registerBuildCacheService(GCSBuildCache::class.java, GCSBuildCacheServiceFactory::class.java)
+            remote(GCSBuildCache::class.java) {
+                isPush = true
+            }
+        }
     }
 }


### PR DESCRIPTION
latest versions and some formatting changes to appease ktlint rules.

added the kotlin-dsl plugin so your plugin implementation uses the same syntax as it is replacing in the settings.gradle(.kts) files.

closes #1 