### PR TITLE
Feature: Support an optional prefix for cached objects

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -15,6 +15,9 @@ The build cache takes the following options:
 |bucket
 |Name of the Google Cloud Storage bucket (required)
 
+|prefix
+|Path prefix for objects written to Google Cloud Storage (optional)
+
 |refreshAfterSeconds
 |Amount of time to wait before the timestamp of a cached artifact that is still in use will be renewed (optional)
 
@@ -54,6 +57,7 @@ buildCache {
     remote( GCSBuildCache.class ) {
         credentials = 'my-key.json' // (optional)
         bucket = 'my-bucket'
+        prefix = 'app-cache' // (optional)
         refreshAfterSeconds = 86400 // 24h (optional)
         writeThreshold = 8 * 1024 * 1024 // 8 MiB
         enabled = true
@@ -92,6 +96,7 @@ buildCache {
     remote( GCSBuildCache.class ) {
         credentials = 'my-key.json' // (optional)
         bucket = 'my-bucket'
+        prefix = 'app-cache' // (optional)
         refreshAfterSeconds = 86400 // 24h (optional)
         writeThreshold = 8 * 1024 * 1024 // 8 MiB
         enabled = true
@@ -131,6 +136,7 @@ gradle.settingsEvaluated { settings ->
         remote( GCSBuildCache.class ) {
             credentials = 'my-key.json' // (optional)
             bucket = 'my-bucket'
+            prefix = 'app-cache' // (optional)
             refreshAfterSeconds = 86400 // 24h (optional)
             writeThreshold = 8 * 1024 * 1024 // 8 MiB
             enabled = true

--- a/src/main/kotlin/net/idlestate/gradle/caching/GCSBuildCache.kt
+++ b/src/main/kotlin/net/idlestate/gradle/caching/GCSBuildCache.kt
@@ -26,6 +26,7 @@ import org.gradle.caching.configuration.AbstractBuildCache
 abstract class GCSBuildCache(
     var credentials: String? = "",
     var bucket: String? = "",
+    var prefix: String? = null,
     var refreshAfterSeconds: Int? = 0,
     var writeThreshold: Int? = DEFAULT_WRITE_THRESHOLD,
 ) : AbstractBuildCache()

--- a/src/main/kotlin/net/idlestate/gradle/caching/GCSBuildCacheService.kt
+++ b/src/main/kotlin/net/idlestate/gradle/caching/GCSBuildCacheService.kt
@@ -39,7 +39,7 @@ import java.time.Instant
  *
  * @author Thorsten Ehlers (thorsten.ehlers@googlemail.com) (initial creation)
  */
-class GCSBuildCacheService(credentials: String, val bucketName: String, val prefix: String, val refreshAfterSeconds: Long, val writeThreshold: Int) : BuildCacheService {
+class GCSBuildCacheService(credentials: String, val bucketName: String, val prefix: String?, val refreshAfterSeconds: Long, val writeThreshold: Int) : BuildCacheService {
     private val bucket: Bucket
     init {
         try {
@@ -63,7 +63,7 @@ class GCSBuildCacheService(credentials: String, val bucketName: String, val pref
     override fun store(key: BuildCacheKey, writer: BuildCacheEntryWriter) {
         val value = FileBackedOutputStream(writeThreshold, true)
         writer.writeTo(value)
-        val path = prefix + key.hashCode
+        val path = listOfNotNull(prefix, key.hashCode).joinToString("/")
 
         try {
             value.asByteSource().openBufferedStream().use {
@@ -75,7 +75,7 @@ class GCSBuildCacheService(credentials: String, val bucketName: String, val pref
     }
 
     override fun load(key: BuildCacheKey, reader: BuildCacheEntryReader): Boolean {
-        val path = prefix + key.hashCode
+        val path = listOfNotNull(prefix, key.hashCode).joinToString("/")
         try {
             val blob = bucket.get(path)
 

--- a/src/main/kotlin/net/idlestate/gradle/caching/GCSBuildCacheService.kt
+++ b/src/main/kotlin/net/idlestate/gradle/caching/GCSBuildCacheService.kt
@@ -39,7 +39,7 @@ import java.time.Instant
  *
  * @author Thorsten Ehlers (thorsten.ehlers@googlemail.com) (initial creation)
  */
-class GCSBuildCacheService(credentials: String, val bucketName: String, val refreshAfterSeconds: Long, val writeThreshold: Int) : BuildCacheService {
+class GCSBuildCacheService(credentials: String, val bucketName: String, val prefix: String, val refreshAfterSeconds: Long, val writeThreshold: Int) : BuildCacheService {
     private val bucket: Bucket
     init {
         try {
@@ -63,19 +63,21 @@ class GCSBuildCacheService(credentials: String, val bucketName: String, val refr
     override fun store(key: BuildCacheKey, writer: BuildCacheEntryWriter) {
         val value = FileBackedOutputStream(writeThreshold, true)
         writer.writeTo(value)
+        val path = prefix + key.hashCode
 
         try {
             value.asByteSource().openBufferedStream().use {
-                bucket.create(key.hashCode, it)
+                bucket.create(path, it)
             }
         } catch (e: StorageException) {
-            throw BuildCacheException("Unable to store '${key.hashCode}' in Google Cloud Storage bucket '$bucketName'.", e)
+            throw BuildCacheException("Unable to store '${path}' in Google Cloud Storage bucket '$bucketName'.", e)
         }
     }
 
     override fun load(key: BuildCacheKey, reader: BuildCacheEntryReader): Boolean {
+        val path = prefix + key.hashCode
         try {
-            val blob = bucket.get(key.hashCode)
+            val blob = bucket.get(path)
 
             if (blob != null) {
                 reader.readFrom(Channels.newInputStream(blob.reader()))
@@ -84,7 +86,7 @@ class GCSBuildCacheService(credentials: String, val bucketName: String, val refr
                     // Update creation time so that artifacts that are still used won't be deleted.
                     val createTime = blob.createTimeOffsetDateTime.toInstant()
                     if (createTime.plusSeconds(refreshAfterSeconds).isBefore(Instant.now())) {
-                        bucket.create(key.hashCode, blob.getContent())
+                        bucket.create(path, blob.getContent())
                     }
                 }
 
@@ -96,7 +98,7 @@ class GCSBuildCacheService(credentials: String, val bucketName: String, val refr
                 return false
             }
 
-            throw BuildCacheException("Unable to load '${key.hashCode}' from Google Cloud Storage bucket '$bucketName'.", e)
+            throw BuildCacheException("Unable to load '${path}' from Google Cloud Storage bucket '$bucketName'.", e)
         }
 
         return false

--- a/src/main/kotlin/net/idlestate/gradle/caching/GCSBuildCacheServiceFactory.kt
+++ b/src/main/kotlin/net/idlestate/gradle/caching/GCSBuildCacheServiceFactory.kt
@@ -28,6 +28,7 @@ class GCSBuildCacheServiceFactory : BuildCacheServiceFactory<GCSBuildCache> {
     override fun createBuildCacheService(configuration: GCSBuildCache, describer: BuildCacheServiceFactory.Describer): BuildCacheService {
         val credentials = (if (configuration.credentials == null) "" else configuration.credentials) as String
         val bucket = configuration.bucket
+        val prefix = (if (configuration.prefix == null) "" else configuration.prefix!!.trim('/').plus('/'))
         val refreshAfterSeconds = configuration.refreshAfterSeconds ?: 0
         val writeThreshold = configuration.writeThreshold ?: DEFAULT_WRITE_THRESHOLD
 
@@ -39,10 +40,11 @@ class GCSBuildCacheServiceFactory : BuildCacheServiceFactory<GCSBuildCache> {
             .type("Google Cloud Storage")
             .config("credentials", credentials)
             .config("bucket", bucket)
+            .config("prefix", prefix)
             .config("refreshAfterSeconds", refreshAfterSeconds.toString())
             .config("writeThreshold", writeThreshold.toString())
 
-        return GCSBuildCacheService(credentials, bucket, refreshAfterSeconds.toLong(), writeThreshold)
+        return GCSBuildCacheService(credentials, bucket, prefix, refreshAfterSeconds.toLong(), writeThreshold)
     }
 
     fun gradleException(message: String): GradleException {

--- a/src/main/kotlin/net/idlestate/gradle/caching/GCSBuildCacheServiceFactory.kt
+++ b/src/main/kotlin/net/idlestate/gradle/caching/GCSBuildCacheServiceFactory.kt
@@ -28,7 +28,7 @@ class GCSBuildCacheServiceFactory : BuildCacheServiceFactory<GCSBuildCache> {
     override fun createBuildCacheService(configuration: GCSBuildCache, describer: BuildCacheServiceFactory.Describer): BuildCacheService {
         val credentials = (if (configuration.credentials == null) "" else configuration.credentials) as String
         val bucket = configuration.bucket
-        val prefix = (if (configuration.prefix == null) "" else configuration.prefix!!.trim('/').plus('/'))
+        val prefix = configuration.prefix
         val refreshAfterSeconds = configuration.refreshAfterSeconds ?: 0
         val writeThreshold = configuration.writeThreshold ?: DEFAULT_WRITE_THRESHOLD
 
@@ -40,7 +40,7 @@ class GCSBuildCacheServiceFactory : BuildCacheServiceFactory<GCSBuildCache> {
             .type("Google Cloud Storage")
             .config("credentials", credentials)
             .config("bucket", bucket)
-            .config("prefix", prefix)
+            .config("prefix", prefix ?: "<unset>")
             .config("refreshAfterSeconds", refreshAfterSeconds.toString())
             .config("writeThreshold", writeThreshold.toString())
 


### PR DESCRIPTION
Closes #13.

I am new to Kotlin so I apologise in advance if my code isn't idiomatic! 

I've verified that the plugin works:
- without a prefix set
- with a single path element set (eg `prefix = "gradle"`)
- with multiple path elements set (eg `prefix = "gradle/build"`)