### PR TITLE
Adding support for the `GOOGLE_OAUTH_ACCESS_TOKEN` env var

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -10,7 +10,7 @@ The build cache takes the following options:
 |Option |Description
 
 |credentials
-|JSON key file of the service account to use, otherwise GCP Application Default Credentials are used. (optional)
+|JSON key file of the service account to use, otherwise the `GOOGLE_OAUTH_ACCESS_TOKEN` env var, or GCP Application Default Credentials are used. (optional)
 
 |bucket
 |Name of the Google Cloud Storage bucket (required)

--- a/src/main/kotlin/net/idlestate/gradle/caching/GCSBuildCacheService.kt
+++ b/src/main/kotlin/net/idlestate/gradle/caching/GCSBuildCacheService.kt
@@ -15,6 +15,7 @@
  */
 package net.idlestate.gradle.caching
 
+import com.google.auth.oauth2.AccessToken
 import com.google.auth.oauth2.GoogleCredentials
 import com.google.auth.oauth2.ServiceAccountCredentials
 import com.google.cloud.storage.Bucket
@@ -44,9 +45,7 @@ class GCSBuildCacheService(credentials: String, val bucketName: String, val pref
     init {
         try {
             val storage = StorageOptions.newBuilder()
-                .setCredentials(
-                    if (credentials.isEmpty()) GoogleCredentials.getApplicationDefault() else ServiceAccountCredentials.fromStream(FileInputStream(credentials))
-                )
+                .setCredentials(getGoogleCredentials(credentials))
                 .build()
                 .service
 
@@ -106,5 +105,20 @@ class GCSBuildCacheService(credentials: String, val bucketName: String, val pref
 
     override fun close() {
         // nothing to do
+    }
+
+    private fun getGoogleCredentials(credentials: String): GoogleCredentials {
+        if (credentials.isEmpty()) {
+            // see terraform docs: https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference.html#access_token-1
+            val envAccessToken: String = System.getenv("GOOGLE_OAUTH_ACCESS_TOKEN")
+
+            if (envAccessToken != null) {
+                return GoogleCredentials.create(AccessToken(envAccessToken, null))
+            } else {
+                return GoogleCredentials.getApplicationDefault()
+            }
+        } else {
+            return ServiceAccountCredentials.fromStream(FileInputStream(credentials))
+        }
     }
 }

--- a/src/main/kotlin/net/idlestate/gradle/caching/GCSBuildCacheService.kt
+++ b/src/main/kotlin/net/idlestate/gradle/caching/GCSBuildCacheService.kt
@@ -112,7 +112,7 @@ class GCSBuildCacheService(credentials: String, val bucketName: String, val pref
             // see terraform docs: https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference.html#access_token-1
             val envAccessToken: String = System.getenv("GOOGLE_OAUTH_ACCESS_TOKEN")
 
-            if (envAccessToken != null) {
+            if (envAccessToken != null && !envAccessToken.isEmpty()) {
                 return GoogleCredentials.create(AccessToken(envAccessToken, null))
             } else {
                 return GoogleCredentials.getApplicationDefault()


### PR DESCRIPTION
Adding support for the terraform-style GOOGLE_OAUTH_ACCESS_TOKEN env var.

See terraform documentation:
https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference.html#access_token-1

This is helpful for certain build systems that just have an easier time injecting a temporary raw access token into a pipeline, hence terraform's support for this.

Let me know if this looks good; it's certainly a feature I need, if I want to be able to make use of your cache. I made this account so I could use this in my day job. :)